### PR TITLE
feat: :arrow_up: 兼容NAVM.rs 0.15，包括「终止」命令

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "babel_nar"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -574,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "navm"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcaacc0e150da6d931c9bd71be0b4168c1bac253d5439d1c10dde33862de998b"
+checksum = "40fbc008d70ade7e0b94a9dc005ec297b229a3a3e9b0334e803ba4e605cb7dc7"
 dependencies = [
  "anyhow",
  "nar_dev_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "babel_nar"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = """
 Implementation and application supports of the NAVM model
@@ -54,7 +54,7 @@ features = [
 # ! 本地依赖可以不添加版本
 # 载入NAVM API，引入「非公理虚拟机」模型
 # path = "../NAVM.rs"
-version = "0" # 现已发布于`crates.io`
+version = "0.15" # 现已发布于`crates.io`
 # git = "https://github.com/ARCJ137442/NAVM.rs"
 # ! 【2024-03-23 19:19:01】似乎Rust-Analyzer无法获取私有仓库数据
 features = [] # ! 【2024-03-21 09:24:51】暂时没有特性

--- a/src/cin_implements/opennars/translators.rs
+++ b/src/cin_implements/opennars/translators.rs
@@ -41,6 +41,8 @@ pub fn input_translate(cmd: Cmd) -> Result<String> {
         Cmd::VOL(n) => format!("*volume={n}"),
         // 注释 ⇒ 忽略 | ❓【2024-04-02 22:43:05】可能需要打印，但这样却没法统一IO（到处print的习惯不好）
         Cmd::REM { .. } => String::new(),
+        // 退出码
+        Cmd::EXI { .. } => "*exit".into(),
         // 其它类型
         // * 📌【2024-03-24 22:57:18】基本足够支持
         // ! 🚩【2024-03-27 22:42:56】不使用[`anyhow!`]：打印时会带上一大堆调用堆栈
@@ -95,6 +97,10 @@ pub fn output_translate(content_raw: String) -> Result<Output> {
             content: content_raw,
         },
         "ERR" | "ERROR" => Output::ERROR {
+            description: content_raw,
+        },
+        // * 🚩【2024-05-09 14:41:11】目前为OpenNARS 1.5.8（定制版）专用
+        "TERMINATED" | "EXITED" | "QUITTED" => Output::TERMINATED {
             description: content_raw,
         },
         // * 🚩利用OpenNARS常见输出「全大写」的特征，兼容「confirm」与「disappoint」

--- a/src/test_tools/vm_interact.rs
+++ b/src/test_tools/vm_interact.rs
@@ -1,13 +1,11 @@
 //! 与NAVM虚拟机的交互逻辑
 
-use std::{ops::ControlFlow, path::Path};
-
-use crate::cli_support::{error_handling_boost::error_anyhow, io::output_print::OutputType};
-
 use super::{NALInput, OutputExpectation, OutputExpectationError};
+use crate::cli_support::{error_handling_boost::error_anyhow, io::output_print::OutputType};
 use anyhow::Result;
 use nar_dev_utils::{if_return, ResultBoost};
 use navm::{cmd::Cmd, output::Output, vm::VmRuntime};
+use std::{ops::ControlFlow, path::Path};
 
 /// * 🎯统一存放与「Narsese预期识别」有关的代码
 /// * 🚩【2024-04-02 22:49:12】从[`crate::runtimes::command_vm::runtime::tests`]中迁移而来


### PR DESCRIPTION
1. 兼容NAVM.rs 0.15，增加对`EXI`「退出」指令的转换（兼容OpenNARS 1.5.8定制版）
2. 尝试针对Java程序解决「残留进程锁死主进程」的问题（目前尚未完全实现）
3. 更新有关依赖版本